### PR TITLE
Add /revoke route as per RFC 7009

### DIFF
--- a/src/Revoke.php
+++ b/src/Revoke.php
@@ -6,6 +6,10 @@ use Chadicus\Slim\OAuth2\Http\MessageBridge;
 use OAuth2;
 use Slim\Slim;
 
+/**
+ * The revoke class.
+ * 
+ */
 class Revoke
 {
     const ROUTE = '/revoke';
@@ -27,8 +31,8 @@ class Revoke
     /**
      * Construct a new instance of Authorize.
      *
-     * @param Slim          $slim     The slim framework application instance.
-     * @param OAuth2\Server $server   The oauth2 server imstance.
+     * @param Slim          $slim   The slim framework application instance.
+     * @param OAuth2\Server $server The oauth2 server imstance.
      */
     public function __construct(Slim $slim, OAuth2\Server $server)
     {
@@ -53,8 +57,8 @@ class Revoke
     /**
      * Register this route with the given Slim application and OAuth2 server
      *
-     * @param Slim          $slim     The slim framework application instance.
-     * @param OAuth2\Server $server   The oauth2 server instance.
+     * @param Slim          $slim   The slim framework application instance.
+     * @param OAuth2\Server $server The oauth2 server instance.
      *
      * @return void
      */

--- a/src/Revoke.php
+++ b/src/Revoke.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Chadicus\Slim\OAuth2\Routes;
+
+use Chadicus\Slim\OAuth2\Http\MessageBridge;
+use OAuth2;
+use Slim\Slim;
+
+class Revoke
+{
+    const ROUTE = '/revoke';
+
+    /**
+     * The slim framework application instance.
+     *
+     * @var Slim
+     */
+    private $slim;
+
+    /**
+     * The oauth2 server instance.
+     *
+     * @var OAuth2\Server
+     */
+    private $server;
+
+    /**
+     * Construct a new instance of Authorize.
+     *
+     * @param Slim          $slim     The slim framework application instance.
+     * @param OAuth2\Server $server   The oauth2 server imstance.
+     */
+    public function __construct(Slim $slim, OAuth2\Server $server)
+    {
+        $this->slim = $slim;
+        $this->server = $server;
+    }
+
+    /**
+     * Call this class as a function.
+     *
+     * @return void
+     */
+    public function __invoke()
+    {
+        $request = MessageBridge::newOAuth2Request($this->slim->request());
+        MessageBridge::mapResponse(
+            $this->server->handleRevokeRequest($request),
+            $this->slim->response()
+        );
+    }
+
+    /**
+     * Register this route with the given Slim application and OAuth2 server
+     *
+     * @param Slim          $slim     The slim framework application instance.
+     * @param OAuth2\Server $server   The oauth2 server instance.
+     *
+     * @return void
+     */
+    public static function register(Slim $slim, OAuth2\Server $server)
+    {
+        $slim->post(self::ROUTE, new static($slim, $server))->name('revoke');
+    }
+}


### PR DESCRIPTION
Added /revoke route as per [RFC 7009](https://tools.ietf.org/html/rfc7009#section-2) which was integrated into bshaffer/oauth2-server-php. Request parameters as outlined in the server library should have 'token_type_hint' which is either 'access_token' or 'refresh_token', and 'token' which is the actual token.
