### PR TITLE
Add Content-Type header to response

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -43,10 +43,8 @@ final class Token implements RouteCallbackInterface
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $arguments = [])
     {
-        /** @var OAuth2\Response $response */
-        $response = $this->server->handleTokenRequest(RequestBridge::toOAuth2($request));
-        $response->addHttpHeaders(['Content-Type' => 'application/json']);
-
-        return ResponseBridge::fromOAuth2($response);
+        return ResponseBridge::fromOAuth2(
+            $this->server->handleTokenRequest(RequestBridge::toOAuth2($request))
+        )->withHeader('Content-Type', 'application/json');
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -43,8 +43,14 @@ final class Token implements RouteCallbackInterface
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $arguments = [])
     {
-        return ResponseBridge::fromOAuth2(
+        $response = ResponseBridge::fromOAuth2(
             $this->server->handleTokenRequest(RequestBridge::toOAuth2($request))
-        )->withHeader('Content-Type', 'application/json');
+        );
+
+        if ($response->hasHeader('Content-Type')) {
+            return $response;
+        }
+
+        return $response->withHeader('Content-Type', 'application/json');
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -43,10 +43,10 @@ final class Token implements RouteCallbackInterface
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $arguments = [])
     {
-        return ResponseBridge::fromOAuth2(
-            $this->server->handleTokenRequest(
-                RequestBridge::toOAuth2($request)
-            )
-        );
+        /** @var OAuth2\Response $response */
+        $response = $this->server->handleTokenRequest(RequestBridge::toOAuth2($request));
+        $response->addHttpHeaders(['Content-Type' => 'application/json']);
+
+        return ResponseBridge::fromOAuth2($response);
     }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -128,4 +128,24 @@ final class TokenTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
     }
+
+    /**
+     * Verify Content-Type header remains unchanged if OAuth2 response contains the header.
+     *
+     * @test
+     * @covers ::__invoke
+     *
+     * @return void
+     */
+    public function invokeRetainsContentType()
+    {
+        $oauth2ServerMock = $this->getMockBuilder('\\OAuth2\\Server')->disableOriginalConstructor()->getMock();
+        $oauth2ServerMock->method('handleTokenRequest')->willReturn(
+            new OAuth2\Response([], 200, ['Content-Type' => 'text/html'])
+        );
+
+        $route = new Token($oauth2ServerMock);
+        $response = $route(new ServerRequest(), new Response());
+		$this->assertSame('text/html', $response->getHeaderLine('Content-Type'));
+    }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -126,7 +126,7 @@ final class TokenTest extends \PHPUnit_Framework_TestCase
 
         $response = $route($request, new Response());
 
-		$this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -146,6 +146,6 @@ final class TokenTest extends \PHPUnit_Framework_TestCase
 
         $route = new Token($oauth2ServerMock);
         $response = $route(new ServerRequest(), new Response());
-		$this->assertSame('text/html', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('text/html', $response->getHeaderLine('Content-Type'));
     }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -79,4 +79,53 @@ final class TokenTest extends \PHPUnit_Framework_TestCase
             $actual
         );
     }
+
+    /**
+     * Verify Content-Type header is added to response
+     *
+     * @test
+     * @covers ::__invoke
+     *
+     * @return void
+     */
+    public function invokeAddsContentType()
+    {
+        $storage = new Storage\Memory(
+            [
+                'client_credentials' => [
+                    'testClientId' => [
+                        'client_id' => 'testClientId',
+                        'client_secret' => 'testClientSecret',
+                    ],
+                ],
+            ]
+        );
+
+        $server = new OAuth2\Server(
+            $storage,
+            [
+                'access_lifetime' => 3600,
+            ],
+            [
+                new GrantType\ClientCredentials($storage),
+            ]
+        );
+
+        $uri = 'localhost:8888/token';
+
+        $headers = ['Content-Type' => ['application/json']];
+
+        $body = [
+            'client_id' => 'testClientId',
+            'client_secret' => 'testClientSecret',
+            'grant_type' => 'client_credentials',
+        ];
+        $request = new ServerRequest(['REQUEST_METHOD' => 'POST'], [], $uri, 'POST', 'php://input', $headers, [], [], $body);
+
+        $route = new Token($server);
+
+        $response = $route($request, new Response());
+
+		$this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+    }
 }


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request
This pull request is built on top of @Achse previous PR.  It adds the response `Content-Type` header if it does not exist.
## Checklist
- [ ] Unit Tests Added
- [ ] Documentation Updated
