### PR TITLE
Allow PHP 8 and bump dependencies for Slim 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 composer.lock
+
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,17 @@
             "role": "Developer"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/tchapi/slim-oauth2-http"
+        }
+      ],
     "license": "MIT",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.9",
-        "chadicus/slim-oauth2-http": "^3.1"
+        "chadicus/slim-oauth2-http": "dev-next"
     },
     "suggest": {
         "chadicus/slim-oauth2-middleware": "Adds OAuth2 middleware for API requests.",
@@ -23,9 +29,9 @@
         "sort-packages": true
     },
     "require-dev": {
-        "chadicus/coding-standard": "^1.3",
-        "php-coveralls/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^5.7",
+        "chadicus/coding-standard": "^1.8",
+        "php-coveralls/php-coveralls": "^2.5",
+        "phpunit/phpunit": "^8.5",
         "slim/php-view": "^2.0.5",
         "zendframework/zend-diactoros": ">=1.3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php-coveralls/php-coveralls": "^2.5",
         "phpunit/phpunit": "^8.5",
         "slim/php-view": "^2.0.5",
-        "zendframework/zend-diactoros": ">=1.3.2"
+        "laminas/laminas-diactoros": "^2.8"
     },
     "autoload": {
         "psr-4": {"Chadicus\\Slim\\OAuth2\\Routes\\" : "src"}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
       ],
     "license": "MIT",
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.9",
         "chadicus/slim-oauth2-http": "dev-next"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "sort-packages": true
     },
     "require-dev": {
-        "chadicus/coding-standard": "^1.8",
+        "squizlabs/php_codesniffer": "^3.2",
         "php-coveralls/php-coveralls": "^2.5",
         "phpunit/phpunit": "^8.5",
         "slim/php-view": "^2.0.5",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,5 @@
 <ruleset name="PHP_CodeSniffer">
     <file>.</file>
     <exclude-pattern>*/vendor/*</exclude-pattern>
-    <arg value="p" />
-    <rule ref="./vendor/chadicus/coding-standard/Chadicus"/>
+    <rule ref="PSR2"/>
 </ruleset>

--- a/tests/AuthorizeTest.php
+++ b/tests/AuthorizeTest.php
@@ -9,6 +9,7 @@ use Slim\Views;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Routes\Authorize class.
@@ -17,7 +18,7 @@ use Zend\Diactoros\Stream;
  * @covers ::<private>
  * @covers ::__construct
  */
-final class AuthorizeTest extends \PHPUnit_Framework_TestCase
+final class AuthorizeTest extends TestCase
 {
     /**
      * Verify behavior of __invoke() with no client_id parameter
@@ -205,13 +206,14 @@ HTML;
      *
      * @test
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMethod $view must implement a render() method
      *
      * @return void
      */
     public function constructWithInvalidView()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$view must implement a render() method');
+
         $server = new OAuth2\Server(new Storage\Memory([]), [], []);
         new Authorize($server, new \StdClass());
     }

--- a/tests/AuthorizeTest.php
+++ b/tests/AuthorizeTest.php
@@ -6,9 +6,9 @@ use Chadicus\Slim\OAuth2\Routes\Authorize;
 use OAuth2;
 use OAuth2\Storage;
 use Slim\Views;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Stream;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/ReceiveCodeTest.php
+++ b/tests/ReceiveCodeTest.php
@@ -10,6 +10,7 @@ use Slim\Views;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Routes\ReceiveCode class.
@@ -18,7 +19,7 @@ use Zend\Diactoros\Stream;
  * @covers ::<private>
  * @covers ::__construct
  */
-final class ReceiveCodeTest extends \PHPUnit_Framework_TestCase
+final class ReceiveCodeTest extends TestCase
 {
     /**
      * Verify basic behavior of __invoke()
@@ -83,13 +84,14 @@ final class ReceiveCodeTest extends \PHPUnit_Framework_TestCase
      *
      * @test
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMethod $view must implement a render() method
      *
      * @return void
      */
     public function constructWithInvalidView()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$view must implement a render() method');
+
         $server = new OAuth2\Server(new Storage\Memory([]), [], []);
         new ReceiveCode($server, new \StdClass());
     }

--- a/tests/ReceiveCodeTest.php
+++ b/tests/ReceiveCodeTest.php
@@ -7,9 +7,9 @@ use OAuth2;
 use OAuth2\GrantType;
 use OAuth2\Storage;
 use Slim\Views;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Stream;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/RevokeTest.php
+++ b/tests/RevokeTest.php
@@ -6,9 +6,9 @@ use Chadicus\Slim\OAuth2\Routes\Revoke;
 use OAuth2;
 use OAuth2\Storage;
 use OAuth2\GrantType;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Stream;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/RevokeTest.php
+++ b/tests/RevokeTest.php
@@ -9,6 +9,7 @@ use OAuth2\GrantType;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Routes\Revoke class.
@@ -17,7 +18,7 @@ use Zend\Diactoros\Stream;
  * @covers ::<private>
  * @covers ::__construct
  */
-final class RevokeTest extends \PHPUnit_Framework_TestCase
+final class RevokeTest extends TestCase
 {
     /**
      * Verify basic behavior of __invoke()

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -6,9 +6,9 @@ use Chadicus\Slim\OAuth2\Routes\Token;
 use OAuth2;
 use OAuth2\GrantType;
 use OAuth2\Storage;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Stream;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -9,6 +9,7 @@ use OAuth2\Storage;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Routes\Token class.
@@ -17,7 +18,7 @@ use Zend\Diactoros\Stream;
  * @covers ::<private>
  * @covers ::__construct
  */
-final class TokenTest extends \PHPUnit_Framework_TestCase
+final class TokenTest extends TestCase
 {
     /**
      * Verify basic behavior of __invoke()

--- a/tests/UserIdProviderTest.php
+++ b/tests/UserIdProviderTest.php
@@ -4,11 +4,12 @@ namespace ChadicusTest\Slim\OAuth2\Routes;
 
 use Chadicus\Slim\OAuth2\Routes\UserIdProvider;
 use Zend\Diactoros\ServerRequest;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Chadicus\Slim\OAuth2\Routes\UserIdProvider
  */
-final class UserIdProviderTest extends \PHPUnit_Framework_TestCase
+final class UserIdProviderTest extends TestCase
 {
     /**
      * Verify basic behavior of getUserId()

--- a/tests/UserIdProviderTest.php
+++ b/tests/UserIdProviderTest.php
@@ -3,7 +3,7 @@
 namespace ChadicusTest\Slim\OAuth2\Routes;
 
 use Chadicus\Slim\OAuth2\Routes\UserIdProvider;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
#### What does this PR do?

This PR allows the package to be used with Slim 4 / PHP 8, and update dependencies and dev dependencies.
It also fixes tests and phpcs configuration.

I chose to mimic the `php` dependency of **Slim 4** (`^7.4 || ^8.0`) to be consistent with the framework.

After this PR, a new major release should be created, and the README should be updated accordingly to reflect the two versions: `3.x` for Slim 3 and `4.x` for Slim 4

Happy to discuss and make modifications if necessary

#### Relevant PRs in other repositories

  - https://github.com/chadicus/slim-oauth2-http/pull/50
  - https://github.com/chadicus/slim-oauth2-middleware/pull/63
  - Original work for middleware package: https://github.com/chadicus/slim-oauth2-middleware/pull/48
 
#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated -> The README should be updated afterwards
